### PR TITLE
Adding support for full name on check_spoken_language-method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Pycharm .idea folder
+.idea

--- a/gtrending/fetch.py
+++ b/gtrending/fetch.py
@@ -118,22 +118,25 @@ def check_language(language: str = "") -> bool:
     return False
 
 
-def check_spoken_language(spoken_language_code: str = "") -> bool:
+def check_spoken_language(spoken_language: str = "") -> bool:
     """Check if the spoken language exists.
 
     Parameters:
-        spoken_language_code (str): The spoken language, eg: en for english.
+        spoken_language (str): The spoken language, eg: English, or en, for English.
 
     Returns:
         A boolean value. True for valid spoken language, False otherwise.
     """
-    spoken_languages = spoken_languages_list()
-    spoken_language_code = spoken_language_code.lower()
-
-    for name in spoken_languages:
-        if spoken_language_code == name["urlParam"].lower():
-            return True
-
+    spoken_language = spoken_language.lower()
+    spoken_languages = []
+    spoken_language_codes = []
+    for entry in spoken_languages_list():
+        spoken_languages.extend(entry.get("name").split(", "))
+        spoken_language_codes.append(entry.get("urlParam"))
+    if spoken_language.title() in spoken_languages:
+        return True
+    if spoken_language in spoken_language_codes:
+        return True
     return False
 
 

--- a/gtrending/fetch.py
+++ b/gtrending/fetch.py
@@ -129,13 +129,10 @@ def check_spoken_language(spoken_language: str = "") -> bool:
     """
     spoken_language = spoken_language.lower()
     spoken_languages = []
-    spoken_language_codes = []
     for entry in spoken_languages_list():
         spoken_languages.extend(entry.get("name").split(", "))
-        spoken_language_codes.append(entry.get("urlParam"))
-    if spoken_language.title() in spoken_languages:
-        return True
-    if spoken_language in spoken_language_codes:
+        spoken_languages.append(entry.get("urlParam"))
+    if spoken_language.title() in spoken_languages or spoken_language in spoken_languages:
         return True
     return False
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -10,6 +10,8 @@ def test_check_language():
 def test_check_spoken_language():
     assert check_spoken_language("en")
     assert check_spoken_language("es")
+    assert check_spoken_language("English")
+    assert check_spoken_language("spanish")
     assert not check_spoken_language("notreal")
 
 


### PR DESCRIPTION
I thought it would be a nice improvement to allow checking both language-codes and full name languages for the checking-method.