### PR TITLE
Adding CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ for repo in repos:
     print(repo["fullname"])  # "user/repo" for each repo
 ```
 
-The above example will fetch all the trending Python projects on GitHub
-trending today and print their full names.
+or using the CLI
+
+```sh
+gtrending repos --language python
+```
+
+The above examples will fetch all the trending Python projects on GitHub
+trending today.
+
+
 
 
 ## Requirements
@@ -137,6 +145,63 @@ Returns:
 > A boolean value. True for valid parameter, False otherwise.
 
 ---
+
+## CLI
+
+Usage:
+```
+gtrending [--json] <command> [<args>]
+```
+
+### Quick Examples
+```sh
+# Sort repos by stars
+gtrending repos --sort stars       
+
+# See only python repositories
+gtrending repos --language python  
+
+# See weekly trending repos
+gtrending repos --since weekly --sort forks  
+
+# Print output in json format (-j/--json)
+gtrending repos --json             
+
+# See trending rust developers
+gtrending developers --language rust
+
+# See available coding languages
+gtrending langs
+
+# See available spoken languages
+gtrending spoken-langs
+
+
+# Help commands
+gtrending --help
+# or see available arguments for specific sub-command
+gtrending developers --help
+
+
+
+## Usage with jq
+
+# Show only fullname (user/repo) and total stars for each repo
+gtrending repos --json | jq '[.[] | {fullname, stars}]'  # Still a json output
+
+# Show only fullname for repos
+gtrending repos --json | jq '.[] | .fullname'            # Not a json anymore
+
+# Similarly for trending developers
+# Show only username and repository url
+gtrending developers -j | jq '.[] | {username, repo: .repo.url}'
+
+# Show only developers with a sponsorUrl
+gtrending developers -j | jq 'map(select(.sponsorUrl != null)) | .[] | {username, repo_name: .repo.name}'
+```
+
+
+
 
 ## Uses
 

--- a/gtrending/__main__.py
+++ b/gtrending/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/gtrending/cli.py
+++ b/gtrending/cli.py
@@ -12,28 +12,57 @@ from .fetch import (
 
 
 def main():
+    parser = argparse.ArgumentParser(
+        'gtrending',
+        description='Query the GitHub Trending page',
+        usage='gtrending <command>',
+        epilog='Run `gtrending <command> --help` for more details',
+    )
 
-    parser = argparse.ArgumentParser('Gtrending')
-    subparser = parser.add_subparsers(dest='command')
+    # This is a workaround to allow `--json` to be used before command names
+    # like `gtrending --json repos` and to keep `--json` in the main help message
+    parser.add_argument(
+        '-j',
+        '--json',
+        help='print output in json format',
+        action='store_true',
+        default=False,
+        dest='json_main'   # see: https://stackoverflow.com/a/37933841
+    )
+
+    subparser = parser.add_subparsers(
+        title='commands',
+        dest='command',
+        prog='gtrending'
+    )
   
     # Extract common arguments in parents
     parent_json = argparse.ArgumentParser(add_help=False)
     parent_json.add_argument(
+        '-j',
         '--json',
-        '-J',
-        action=argparse.BooleanOptionalAction,
+        dest='json',
+        help='see output in json format',
+        action='store_true',
         default=False,
     )
 
     parent_filter = argparse.ArgumentParser(add_help=False)
     parent_filter.add_argument(
+        '-l',
         '--language',
-        '--lang',
+        dest='language',
+        metavar='lang',
+        help='One of the supported coding langauges',
         default=""
     )
     parent_filter.add_argument(
+        '-s',
         '--since',
+        dest='since',
         type=str,
+        metavar='duration',
+        help="Options: 'daily', 'monthly' or 'weekly'",
         choices=['daily', 'monthly', 'weekly'],
         default='daily'
     )
@@ -41,23 +70,30 @@ def main():
 
     parser_repo = subparser.add_parser(
         'repos',
+        help='fetch trending repos',
         parents=[parent_json, parent_filter]
     )
     parser_repo.add_argument(
+        '-S',
         '--spoken-language',
-        '--spoken-lang',
+        dest='spoken_language',
+        help='one of the supported spoken languages',
+        metavar='spoken_lang',
         default=""
     )
     parser_repo.add_argument(
         '--sort',
+        metavar='key',
+        help="options: 'name', 'forks' and 'stars'",
         type=str,
         choices=['name', 'forks', 'stars'],
         default='name'
     )
     parser_repo.add_argument(
+        '-r',
         '--sort-reverse',
-        type=bool,
-        action=argparse.BooleanOptionalAction,
+        dest='sort_reverse',
+        action='store_true',
         default=False
     )
     parser_repo.set_defaults(func=show_repos)
@@ -65,6 +101,7 @@ def main():
 
     parser_developer = subparser.add_parser(
         'developers',
+        help='fetch trending developers',
         parents=[parent_json, parent_filter]
     )
     parser_developer.set_defaults(func=show_developers)
@@ -72,6 +109,7 @@ def main():
 
     parser_langs = subparser.add_parser(
         'langs',
+        help='fetch list of supported coding languages',
         parents=[parent_json]
     )
     parser_langs.set_defaults(func=show_langs)
@@ -79,6 +117,7 @@ def main():
 
     parser_spoken_langs = subparser.add_parser(
         'spoken-langs',
+        help='fetch list of supported spoken languages',
         parents=[parent_json]
     )
     parser_spoken_langs.set_defaults(func=show_spoken_langs)
@@ -89,6 +128,7 @@ def main():
         parser.print_help()
         exit(1)
     else:
+        args.json = args.json or args.json_main
         args.func(args)
 
 

--- a/gtrending/cli.py
+++ b/gtrending/cli.py
@@ -11,11 +11,11 @@ from .fetch import (
 )
 
 
-def main():
+def main(args = None):
     parser = argparse.ArgumentParser(
         'gtrending',
         description='Query the GitHub Trending page',
-        usage='gtrending <command>',
+        usage='gtrending [--json] <command> [<args>]',
         epilog='Run `gtrending <command> --help` for more details',
     )
 
@@ -42,7 +42,7 @@ def main():
         '-j',
         '--json',
         dest='json',
-        help='see output in json format',
+        help='print output in json format',
         action='store_true',
         default=False,
     )
@@ -123,7 +123,7 @@ def main():
     parser_spoken_langs.set_defaults(func=show_spoken_langs)
 
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     if args.command == None:
         parser.print_help()
         exit(1)

--- a/gtrending/cli.py
+++ b/gtrending/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 
-from typing import Dict
+from typing import Dict, Any
 
 from .fetch import (
     fetch_repos,
@@ -12,20 +12,169 @@ from .fetch import (
     check_spoken_language,
     check_since,
 )
+"""
+gtrending repos
+gtrending devs|developers
+gtrending lang|code-lang
+gtrending spoken-lang
 
+"""
+
+def print_json(value):
+    print(json.dumps(value, indent=2))
+
+def _repr_item(title: str, props: Dict[str, Any]) -> str:
+    string = title + '\n'
+    indent = " "*4 
+    max_key_len = len(max(props.keys(), key=len))
+    for key, value in props.items():
+        string += indent + (key + ':').ljust(max_key_len+2) + str(value) + "\n"
+    return string
+    
 
 def repr_repo(repo: Dict) -> str:
-    return f"""{repo['fullname']}
-    Language: {repo['language']}
-    Forks: {repo['forks']}"""
+    title = repo['name']
+    props = {
+        'URL': repo['url'],
+        'Author': repo['author'],
+        'Language': repo['language'],
+        'Forks': repo['forks'],
+        'Stars': repo['stars'],
+    }
+    return _repr_item(title, props)
+
+
+def repr_developer(developer: Dict) -> str:
+    title = developer['username']
+    props = {
+        'Name': developer['name'],
+        'URL': developer['url']
+    }
+
+    if developer['sponsorUrl'] is not None:
+        props['Sponsor'] = developer['sponsorUrl']
+
+    if developer['repo'] is not None:
+        props['Repo'] = developer['repo']['url']
+
+    return _repr_item(title, props)
+
+
+def show_repos(args: argparse.Namespace):
+    repos = fetch_repos(
+        language=args.language,
+        spoken_language_code=args.spoken_language,
+        since=args.since
+    )
+
+    repos.sort(
+        key=lambda repo: repo.get(args.sort),
+        reverse=args.sort_reverse
+    )
+
+    if args.json:
+        print_json(repos)
+    else:
+        for repo in repos:
+            print(repr_repo(repo))
+
+
+def show_developers(args: argparse.Namespace):
+    developers = fetch_developers(
+        language=args.language,
+        since=args.since
+    )
+
+    developers.sort(key = lambda dev: dev['username'])
+
+    if args.json:
+        print_json(developers)
+    else:
+        for dev in developers:
+            print(repr_developer(dev))
+
+
+def show_langs(args: argparse.Namespace):
+    langauges = languages_list()
+
+    if args.json:
+        print_json(langauges)
+    else:
+        for entry in languages_list():
+            print(entry["name"])
+
+
+def show_spoken_langs(args: argparse.Namespace):
+    spoken_languages = spoken_languages_list()
+
+    if args.json:
+        print_json(spoken_languages)
+    else:
+        for entry in spoken_languages_list():
+            print(entry["urlParam"], entry["name"])
+
 
 def main():
-    arg_parser = argparse.ArgumentParser('Gtrending')
-    arg_parser.add_argument('--json', '-J', action=argparse.BooleanOptionalAction, default=False)
-    args = arg_parser.parse_args()
-    repos = fetch_repos()
-    if args.json:
-        print(json.dumps(repos, indent=2))
+    json_parser = argparse.ArgumentParser(add_help=False)
+    json_parser.add_argument(
+        '--json',
+        '-J',
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+
+    parser = argparse.ArgumentParser('Gtrending')
+    subparser = parser.add_subparsers(dest='command')
+  
+
+    parser_repo = subparser.add_parser(
+        'repos',
+        parents=[json_parser]
+    )
+    parser_repo.add_argument(
+        '--language',
+        '--lang',
+        '-L',
+        default=""
+    )
+    parser_repo.add_argument(
+        '--spoken-language',
+        '--spoken-lang',
+        default=""
+    )
+    parser_repo.add_argument('--since', type=str, choices=['daily', 'monthly', 'weekly'], default='daily')
+    parser_repo.add_argument('--sort', type=str, choices=['name', 'forks', 'stars'], default='name')
+    parser_repo.add_argument('--sort-reverse', type=bool, action=argparse.BooleanOptionalAction, default=False)
+    parser_repo.set_defaults(func=show_repos)
+
+    # Developer command
+    parser_developer = subparser.add_parser(
+        'developers',
+        parents=[json_parser]
+    )
+    parser_developer.add_argument(
+        '--language',
+        '--lang',
+        '-L',
+        default=""
+    )
+    parser_developer.add_argument(
+        '--since',
+        type=str,
+        choices=['daily', 'monthly', 'weekly'],
+        default='daily'
+    )
+    parser_developer.set_defaults(func=show_developers)
+
+    parser_developer = subparser.add_parser('langs', parents=[json_parser])
+    parser_developer.set_defaults(func=show_langs)
+
+    parser_developer = subparser.add_parser('spoken-langs', parents=[json_parser])
+    parser_developer.set_defaults(func=show_spoken_langs)
+
+    args = parser.parse_args()
+    if args.command == None:
+        parser.print_help()
+        exit(1)
     else:
-        for repo in fetch_repos():
-            print(repr_repo(repo))
+        args.func(args)

--- a/gtrending/cli.py
+++ b/gtrending/cli.py
@@ -62,6 +62,7 @@ def main():
     )
     parser_repo.set_defaults(func=show_repos)
 
+
     parser_developer = subparser.add_parser(
         'developers',
         parents=[parent_json, parent_filter]
@@ -107,10 +108,10 @@ def show_developers(args: argparse.Namespace):
 
 
 def show_langs(args: argparse.Namespace):
-    langauges = languages_list()
+    languages = languages_list()
 
     if args.json:
-        print_json(langauges)
+        print_json(languages)
     else:
         for entry in languages_list():
             print(entry["name"])
@@ -134,7 +135,7 @@ def show_repos(args: argparse.Namespace):
     )
 
     repos.sort(
-        key=lambda repo: repo.get(args.sort),
+        key=lambda repo: repo[args.sort],
         reverse=args.sort_reverse
     )
 

--- a/gtrending/cli.py
+++ b/gtrending/cli.py
@@ -1,0 +1,31 @@
+import argparse
+import json
+
+from typing import Dict
+
+from .fetch import (
+    fetch_repos,
+    fetch_developers,
+    languages_list,
+    spoken_languages_list,
+    check_language,
+    check_spoken_language,
+    check_since,
+)
+
+
+def repr_repo(repo: Dict) -> str:
+    return f"""{repo['fullname']}
+    Language: {repo['language']}
+    Forks: {repo['forks']}"""
+
+def main():
+    arg_parser = argparse.ArgumentParser('Gtrending')
+    arg_parser.add_argument('--json', '-J', action=argparse.BooleanOptionalAction, default=False)
+    args = arg_parser.parse_args()
+    repos = fetch_repos()
+    if args.json:
+        print(json.dumps(repos, indent=2))
+    else:
+        for repo in fetch_repos():
+            print(repr_repo(repo))

--- a/gtrending/fetch.py
+++ b/gtrending/fetch.py
@@ -50,7 +50,7 @@ def fetch_repos(
     return repos
 
 
-def fetch_developers(language: str = "", since: str = "daily") -> dict:
+def fetch_developers(language: str = "", since: str = "daily") -> List[dict]:
     """Fetch trending developers on GitHub.
 
     Parameters:

--- a/gtrending/fetch.py
+++ b/gtrending/fetch.py
@@ -45,7 +45,7 @@ def fetch_repos(
         repo_language = repo.get("language")
         if language:
             if not repo_language or repo_language.lower() != language.lower():
-                continue
+                continue  # pragma: no cover
         repos.append(repo)
     return repos
 

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,7 @@ setup(
     install_requires=[
         "requests>=2.22.0",
     ],
+    entry_points = {
+        'console_scripts': ['gtrending=gtrending.cli:main']
+    },
 )

--- a/tests/cli/test_cli_collection_lists.py
+++ b/tests/cli/test_cli_collection_lists.py
@@ -1,0 +1,29 @@
+import re
+import json
+
+
+def test_langauge_list(run_cli):
+    output = run_cli('langs')
+    assert re.search(r'\bPython\b', output) is not None
+    assert re.search(r'\bJavaScript\b', output) is not None
+
+def test_langauge_list_json(run_cli):
+    output = json.loads(run_cli('langs -j'))
+    for i in output:
+        assert isinstance(i, dict)
+        for key in i.keys():
+            assert isinstance(key, str)
+            assert isinstance(i[key], str)
+
+def test_spoken_langauge_list(run_cli):
+    output = run_cli('spoken-langs')
+    for line in output.strip().splitlines():
+        assert re.fullmatch(r'\w\w .*', line)
+
+def test_spoken_langauge_list_json(run_cli):
+    output = json.loads(run_cli('spoken-langs -j'))
+    for i in output:
+        assert isinstance(i, dict)
+        for key in i.keys():
+            assert isinstance(key, str)
+            assert isinstance(i[key], str)

--- a/tests/cli/test_developers.py
+++ b/tests/cli/test_developers.py
@@ -1,0 +1,26 @@
+import re
+import pytest
+import json
+
+
+def test_json_output(run_cli, developer_assertion):
+    output = json.loads(run_cli('developers -j'))
+
+    developer_assertion(output)
+    assert len(output) != 0
+
+def test_non_json_output(run_cli):
+    output = run_cli('developers')
+
+    # https://regex101.com/r/CccCCk/4
+    assert re.match(r"(^[^\s]+\n((.+)\n){2,4}\n)+", output)
+
+@pytest.mark.parametrize('lang', ['python', 'rust'])
+def test_language(run_cli, developer_assertion, lang):
+    output = json.loads(run_cli(f'developers -j --lang {lang}'))
+    developer_assertion(output)
+
+@pytest.mark.parametrize('since', ['daily', 'weekly', 'monthly'])
+def test_since(run_cli, developer_assertion, since):
+    output = json.loads(run_cli(f'developers -j --since {since}'))
+    developer_assertion(output)

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+def test_no_command(run_cli):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        run_cli('')
+    assert pytest_wrapped_e.value.code != 0
+
+def test_unknown_command(run_cli):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        run_cli('foo')
+    assert pytest_wrapped_e.value.code != 0
+
+def test_unknown_arg(run_cli):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        run_cli('repos --home')
+    assert pytest_wrapped_e.value.code != 0
+
+def test_unknown_arg_value(run_cli):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        run_cli('repos --since yearly')
+    assert pytest_wrapped_e.value.code != 0

--- a/tests/cli/test_execution.py
+++ b/tests/cli/test_execution.py
@@ -1,0 +1,10 @@
+import os
+
+
+def test_named_execution():
+    exit_code = os.system("gtrending --help")
+    assert exit_code == 0
+
+def test_module_execution():
+    exit_code = os.system("python -m gtrending --help")
+    assert exit_code == 0

--- a/tests/cli/test_repos.py
+++ b/tests/cli/test_repos.py
@@ -1,0 +1,33 @@
+import pytest
+import re
+import json
+
+
+def test_json_output(run_cli, repo_assertion):
+    output = json.loads(run_cli('repos -j'))
+
+    assert len(output) != 0
+    repo_assertion(output)
+
+
+def test_non_json_output(run_cli):
+    output = run_cli('repos')
+
+    # https://regex101.com/r/CccCCk/4
+    assert re.match(r"(^[^\s]+\n((.+)\n){5}\n)+", output)
+    
+
+@pytest.mark.parametrize('lang', ['python', 'rust'])
+def test_language(run_cli, repo_assertion, lang):
+    output = json.loads(run_cli(f'repos --lang {lang} -j'))
+    repo_assertion(output, lang)
+
+
+
+@pytest.mark.parametrize("sort_key", ['name', 'forks', 'stars'])
+def test_sorting(sort_key, run_cli, repo_assertion):
+    output = json.loads(run_cli(f'repos --sort {sort_key} -j'))
+    repo_assertion(output)
+
+    assert output == sorted(output, key=lambda repo: repo[sort_key])
+

--- a/tests/cli/test_repr.py
+++ b/tests/cli/test_repr.py
@@ -1,0 +1,95 @@
+from gtrending import cli
+import textwrap
+import pytest
+
+@pytest.fixture
+def example_developer(): 
+    return {
+        "username": "alex",
+        "name": "Alex Gaynor",
+        "url": "https://github.com/alex",
+        "sponsorUrl": None,
+        "avatar": "https://avatars.githubusercontent.com/u/772",
+        "repo": {
+            "name": "what-happens-when",
+            "description": 'An attempt ...',
+            "url": "https://github.com/alex/what-happens-when",
+        },
+    }
+
+def test_repr_item():
+    string = cli.repr_item(
+        "My Title", {"First_Key": "My First Value", "Second-Key": 42}
+    )
+    assert string == textwrap.dedent(
+        """\
+        My Title
+            First_Key:  My First Value
+            Second-Key: 42
+        """
+    )
+
+def test_repr_repo():
+    example_repo = {
+        "author": "Automattic",
+        "name": "pocket-casts-android",
+        "avatar": "https://github.com/Automattic.png",
+        "description": "Pocket Casts Android 🎧",
+        "url": "https://github.com/Automattic/pocket-casts-android",
+        "language": "Kotlin",
+        "languageColor": "#A97BFF",
+        "stars": 1495,
+        "forks": 86,
+        "currentPeriodStars": 246,
+        "builtBy": [
+            {
+                "username": "ashiagr",
+                "href": "https://github.com/ashiagr",
+                "avatar": "https://avatars.githubusercontent.com/u/1405144",
+            },
+        ],
+        "fullname": "Automattic/pocket-casts-android",
+    }
+
+    string = cli.repr_repo(example_repo)
+
+    assert string == textwrap.dedent(
+        """\
+        pocket-casts-android
+            URL:      https://github.com/Automattic/pocket-casts-android
+            Author:   Automattic
+            Language: Kotlin
+            Forks:    86
+            Stars:    1495
+        """
+    )
+
+def test_repr_developer_without_sponsor(example_developer):
+
+    string = cli.repr_developer(example_developer)
+    assert string == textwrap.dedent("""\
+        alex
+            Name: Alex Gaynor
+            URL:  https://github.com/alex
+            Repo: https://github.com/alex/what-happens-when
+        """)
+
+def test_repr_developer_with_sponsor(example_developer):
+    example_developer['sponsorUrl'] = 'https://sponsor'
+    string = cli.repr_developer(example_developer)
+    assert string == textwrap.dedent("""\
+        alex
+            Name:    Alex Gaynor
+            URL:     https://github.com/alex
+            Sponsor: https://sponsor
+            Repo:    https://github.com/alex/what-happens-when
+        """)
+
+def test_repr_developer_without_repo(example_developer):
+    example_developer['repo'] = None
+    string = cli.repr_developer(example_developer)
+    assert string == textwrap.dedent("""\
+        alex
+            Name: Alex Gaynor
+            URL:  https://github.com/alex
+        """)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+import pytest
+import shlex
+from gtrending import cli
+
+# pytest shared functions: https://stackoverflow.com/a/42156088
+def repos_basic_assertions(repos, language=""):
+    for repo in repos:
+        assert isinstance(repo["name"], str)
+        assert isinstance(repo["author"], str)
+        assert repo["fullname"] == f"{repo['author']}/{repo['name']}"
+        assert repo["stars"] >= 0
+        assert repo["forks"] >= 0
+        assert repo["url"] == f"https://github.com/{repo['author']}/{repo['name']}"
+        assert isinstance(repo["description"], (str, type(None)))
+        assert repo["currentPeriodStars"] >= 0
+        print(repo.get("language"))
+        assert isinstance(repo.get("language"), (str, type(None)))
+        if language and repo.get("language"):
+            # Sometimes language is None even with language filtering
+            assert str(repo.get("language")).lower() == language
+        if "languageColor" in repo:
+            if repo["languageColor"]:  # It could be None if repo language is None
+                assert len(repo["languageColor"]) in [4, 7]
+                assert repo["languageColor"].startswith("#")
+
+
+def developers_basic_assertions(devs):
+    for developer in devs:
+        assert isinstance(developer["username"], str)
+        assert isinstance(developer["name"], str)
+        # assert developer["type"] in ("organisation", "user")
+        assert developer["url"] == "https://github.com/" + developer["username"]
+        assert "https://avatars" in developer["avatar"]
+        assert "githubusercontent.com/u/" in developer["avatar"]
+        if "repo" in str(developer.keys):
+            repo = developer["repo"]
+            assert isinstance(repo["name"], str)
+            assert isinstance(repo["description"], str)
+            assert (
+                repo["url"]
+                == "https://github.com/" + developer["username"] + "/" + repo["name"]
+            )
+
+@pytest.fixture
+def repo_assertion():
+    return repos_basic_assertions
+
+@pytest.fixture
+def developer_assertion():
+    return developers_basic_assertions
+
+
+@pytest.fixture
+def run_cli(capsys):
+    def _run_cli(command: str) -> str:
+        cli.main(shlex.split(command))
+        captured = capsys.readouterr()
+
+        return captured.out
+    return _run_cli

--- a/tests/test_fetch_developers.py
+++ b/tests/test_fetch_developers.py
@@ -2,41 +2,25 @@ from gtrending import fetch_developers
 import pytest
 
 
-def basic_assertions(devs):
-    for developer in devs:
-        assert isinstance(developer["username"], str)
-        assert isinstance(developer["name"], str)
-        # assert developer["type"] in ("organisation", "user")
-        assert developer["url"] == "https://github.com/" + developer["username"]
-        assert "https://avatars" in developer["avatar"]
-        assert "githubusercontent.com/u/" in developer["avatar"]
-        if "repo" in str(developer.keys):
-            repo = developer["repo"]
-            assert isinstance(repo["name"], str)
-            assert isinstance(repo["description"], str)
-            assert (
-                repo["url"]
-                == "https://github.com/" + developer["username"] + "/" + repo["name"]
-            )
 
 
-def test_all():
+def test_all(developer_assertion):
     res = fetch_developers()
-    basic_assertions(res)
+    developer_assertion(res)
 
 
-def test_language():
+def test_language(developer_assertion):
     res = fetch_developers(language="python")
-    basic_assertions(res)
+    developer_assertion(res)
     res = fetch_developers(language="javascript")
-    basic_assertions(res)
+    developer_assertion(res)
 
 
-def test_since():
+def test_since(developer_assertion):
     res = fetch_developers(since="weekly")
-    basic_assertions(res)
+    developer_assertion(res)
     res = fetch_developers(since="monthly")
-    basic_assertions(res)
+    developer_assertion(res)
 
 
 def test_incorrect_values():

--- a/tests/test_fetch_repos.py
+++ b/tests/test_fetch_repos.py
@@ -2,37 +2,17 @@ from gtrending import fetch_repos
 import pytest
 
 
-def basic_assertions(repos, language=""):
-    for repo in repos:
-        assert isinstance(repo["name"], str)
-        assert isinstance(repo["author"], str)
-        assert repo["fullname"] == f"{repo['author']}/{repo['name']}"
-        assert repo["stars"] >= 0
-        assert repo["forks"] >= 0
-        assert repo["url"] == f"https://github.com/{repo['author']}/{repo['name']}"
-        assert isinstance(repo["description"], (str, type(None)))
-        assert repo["currentPeriodStars"] >= 0
-        print(repo.get("language"))
-        assert isinstance(repo.get("language"), (str, type(None)))
-        if language and repo.get("language"):
-            # Sometimes language is None even with language filtering
-            assert str(repo.get("language")).lower() == language
-        if "languageColor" in repo:
-            if repo["languageColor"]:  # It could be None if repo language is None
-                assert len(repo["languageColor"]) in [4, 7]
-                assert repo["languageColor"].startswith("#")
 
-
-def test_all():
+def test_all(repo_assertion):
     res = fetch_repos()
-    basic_assertions(res)
+    repo_assertion(res)
 
 
-def test_language():
+def test_language(repo_assertion):
     res = fetch_repos(language="python")
-    basic_assertions(res, "python")
+    repo_assertion(res, "python")
     res = fetch_repos(language="javascript")
-    basic_assertions(res, "javascript")
+    repo_assertion(res, "javascript")
 
 
 def test_incorrect_values():


### PR DESCRIPTION
Fixes: #9 

Adds CLI support to the package. It can be executed using both:
```
python -m gtrending
```
and 
```
gtrending
```
- Tasks
  - [x] Add code to support command line execution
  - [x] Update README
  - [x] Add tests